### PR TITLE
Rearrange conda channel order

### DIFF
--- a/envs/conda.yaml
+++ b/envs/conda.yaml
@@ -1,7 +1,7 @@
 name: sm3
 channels:
-    - bioconda
     - conda-forge
-    - defaults
+    - bioconda
+    - nodefaults
 dependencies:
     - bbmap =38.68


### PR DESCRIPTION
I like this small example pipeline to teach Snakemake. I noticed that the bioconda channel was listed as higher priority than conda-forge. This is no longer recommended because some general recipes, eg R packages, were migrated to the conda-forge channel. The idea is to install everything from conda-forge, and then only use the bioconda channel for bioinformatics-specific tools.

https://bioconda.github.io/#usage

Also, I changed `defaults` to `nodefaults`. If you're using conda on an HPC cluster, there's no need to bother checking the defaults channel. At best it will waste time, at worst it could potentially bork the env (only possible if `channel_priority` is not set to `strict`, but unfortunately that is not the default setting).